### PR TITLE
mount the current working directly into container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,20 @@
 from alpine:3.11
 
-add . /nmag-www
-workdir /nmag-www
-
 # Install dependencies
 run apk --no-cache add make bash python py2-pip rsync
 run pip install docutils
 
 # Extract and link r2w
-run tar xzvf rest2web-0.5.1.tar.gz
+run mkdir -p /opt/rest2web
+add rest2web-0.5.1.tar.gz /opt/rest2web/
+workdir /opt/rest2web/
+### Seems docker already unpacks the tar file ... odd
+# run tar xzvf rest2web-0.5.1.tar.gz
 run chmod 755 rest2web-0.5.1/r2w.py
-run ln -s /nmag-www/rest2web-0.5.1/r2w.py /bin/r2w
+run ln -s /opt/rest2web/rest2web-0.5.1/r2w.py /bin/r2w
 
-# Compile the docs
-cmd make r2w
+# work directory
+workdir /nmag-www
+
+cmd bash
+run echo "Compile the docs in the container with 'make r2w'"

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,16 @@ MREV=0.2
 
 WEBROOT=webroot
 
-#use a docker container to build
+# use a docker container to build and run r2w
 docker:
 	docker build -t nmag-www .
-	docker run -it --rm -v "$$PWD"/output:/nmag-www/output nmag-www
+	docker run -it --rm -v "$$PWD":/nmag-www nmag-www make r2w
 
-#debug using a docker container
+# debug using a docker container.
+# Type 'make r2w' in the container to trigger compilation
 docker-debug:
 	docker build -t nmag-www .
-	docker run -it --rm -v "$$PWD"/output:/nmag-www/output nmag-www ash
+	docker run -it --rm -v "$$PWD":/nmag-www nmag-www ash
 
 #run r2w and copy updated static html to local webroot
 r2w:


### PR DESCRIPTION
Mount the current working directly into container. This includes the source files. Thus if the source files change, this is reflecting in the built container.