### PR TITLE
Update the html documentation link

### DIFF
--- a/input/0.2/manualhtml.txt
+++ b/input/0.2/manualhtml.txt
@@ -7,5 +7,5 @@ restindex
       Nmag Manual (html)
     /description
     build: No
-    target: http://nmag.readthedocs.io
+    target: https://nmag-project.github.io/nmag-doc
 /restindex

--- a/input/manualhtml.txt
+++ b/input/manualhtml.txt
@@ -7,5 +7,5 @@ restindex
       Nmag Manual (html)
     /description
     build: No
-    target: http://nmag.readthedocs.io
+    target: https://nmag-project.github.io/nmag-doc
 /restindex


### PR DESCRIPTION
The old documentation link goes to readthedocs.io, which I do not have access to.
I'm updating the link so that it points to the version hosted on github.io.